### PR TITLE
Nt title and notice

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,8 @@ This plugin is part of the SiteWorks project.  It's purpose is to modify a numbe
 * The login screen is replaced with a customised u3a branded version
 * The capabilities to edit and publish pages is added to the 'Author' role
 * Menu position of Independent Analytics plugin (if present) is moved from default
+* The word 'u3a' is added at the end of the HTML page title unless already present in the text, or the constant U3A_NO_TITLE_CHANGE is defined
+* A cautionary notice is shown on the Add New Plugin page unless the constant U3A_NO_ADD_PLUGIN_NOTICE is defined
 
 = Performance related =
 * Removes unnecessary elements from the HTML head section
@@ -55,6 +57,9 @@ If these settings are not provided in wp-config.php then another mechanism must 
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+= 1.0.2 =
+* Bug 1009 - Add 'u3a' at the end of the HTML title tag unless already present (Jan 2004)
+* Feature 1010 - Add cautionary notice to the Add New Plugin page with link to SiteWorks help on plugins
 = 1.0.1 =
 * Bug 914 - Ensure assets to support 'Lightbox for Gallery & Image Block' plugin are loaded on all pages (Nov 2023)
 = 1.0.0 =

--- a/u3a-siteworks-configuration.php
+++ b/u3a-siteworks-configuration.php
@@ -6,7 +6,7 @@
  * Author: u3a SiteWorks team
  * Author URI: https://siteworks.u3a.org.uk/
  * Plugin URI: https://siteworks.u3a.org.uk/
- * Version: 1.0.1
+ * Version: 1.0.2
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
  */
@@ -14,7 +14,7 @@
 if (!defined('ABSPATH')) {
     exit;
 }
-define('SW_CONFIGURATION_VERSION', '1.0.1');  // Set to current plugin version number
+define('SW_CONFIGURATION_VERSION', '1.0.2');  // Set to current plugin version number
 
 /*
  * Use the plugin update service on SiteWorks update server
@@ -357,3 +357,40 @@ function add_security_headers()
 }
 
 add_action("send_headers", "add_security_headers");
+
+/**
+ * Display a cautionary message at the top of the Dashboard Add Plugin page
+ * The notice can be suppressed by defining the constant U3A_NO_ADD_PLUGIN_NOTICE in wp-config.php
+ */
+
+if (!defined('U3A_NO_ADD_PLUGIN_NOTICE')) {
+    add_action('admin_notices', function () {
+        global $pagenow;
+        if ('plugin-install.php' == $pagenow) {
+            print <<< END
+<div class="notice notice-warning is-dismissible" style="background-color:#ffc700;">
+<p style="font-size: 130%"><strong>SiteWorks Notice - Adding plugins</strong></p><p style="font-size: 115%">Adding plugins can result in problems with your website.  Never install a plugin on your production website without thoroughly testing it first.<br>Please refer to the <a href="https://siteworks.u3a.org.uk/docs/plugins/">SiteWorks User Guide</a> for more information.</p>
+</div>
+END;
+        }
+    });
+}
+
+/**
+ * Modify the <title> tag to add the word 'u3a' at the end of the site title
+ * unless the site title already includes 'u3a'
+ * or the constant U3A_NO_TITLE_CHANGE is defined in wp-config.php
+ */
+
+if (!defined('U3A_NO_TITLE_CHANGE')) {
+    add_filter('document_title_parts', function ($title) {
+        if (isset($title['site']) && (stripos($title['site'], 'u3a') === false)) {
+            $title['site'] .= ' u3a';
+        } else {
+            if (stripos($title['title'], 'u3a') === false) {
+                $title['title'] .= ' u3a';
+            }
+        }
+        return $title;
+    });
+}

--- a/u3a-siteworks-configuration.php
+++ b/u3a-siteworks-configuration.php
@@ -378,18 +378,18 @@ END;
 
 /**
  * Modify the <title> tag to add the word 'u3a' at the end of the site title
- * unless the site title already includes 'u3a'
+ * unless the site title already has 'u3a' at the end
  * or the constant U3A_NO_TITLE_CHANGE is defined in wp-config.php
  */
 
 if (!defined('U3A_NO_TITLE_CHANGE')) {
     add_filter('document_title_parts', function ($title) {
-        if (isset($title['site']) && (stripos($title['site'], 'u3a') === false)) {
+        if (isset($title['site']) && (strtolower(substr(rtrim($title['site']), -3)) != 'u3a')) {
             $title['site'] .= ' u3a';
-        } else {
-            if (stripos($title['title'], 'u3a') === false) {
-                $title['title'] .= ' u3a';
-            }
+            return $title;
+        }
+        if (is_home() || is_front_page() && (strtolower(substr(rtrim($title['title']), -3)) != 'u3a')) {
+            $title['title'] .= ' u3a';
         }
         return $title;
     });


### PR DESCRIPTION
Fixes bug 1009 - adds ' u3a' to end of site title when generating HTML title tag (unless already present, or constant U3A_NO_TITLE_CHANGE is defined).
Adds feature 1010 - adds a cautionary notice to the Add New Plugin page (unless the constant U3A_NO_ADD_PLUGIN_NOTICE is defined).