### PR TITLE
Add medium_large to choice of image sizes in block editor

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,7 @@ This plugin is part of the SiteWorks project.  It's purpose is to modify a numbe
 = WordPress functionality =
 * Support for Comments is disabled globally
 * Posts are sorted in alphabetic order of title rather than the default order of post date
+* Add medium_large to the list of image sizes available when adding an image in the block editor.
 * PDF document preview is disabled
 * The login screen is replaced with a customised u3a branded version
 * The capabilities to edit and publish pages is added to the 'Author' role
@@ -59,6 +60,7 @@ If these settings are not provided in wp-config.php then another mechanism must 
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Add medium_large to the list of image sizes available when adding an image in the block editor. (March 2024)
 * Feature 1025 (and others) - An author can not delete a group where they have been assigned as the author (March 2024)
 = 1.0.1 =
 * Bug 914 - Ensure assets to support 'Lightbox for Gallery & Image Block' plugin are loaded on all pages (Nov 2023)

--- a/u3a-siteworks-configuration.php
+++ b/u3a-siteworks-configuration.php
@@ -161,6 +161,21 @@ function set_post_order_in_admin($wp_query)
 add_filter('pre_get_posts', 'set_post_order_in_admin');
 
 
+/* Add medium_large to the list of image sizes to choose from in
+ * the RESOLUTION setting when adding an image in the block editor.
+ * Add pixel sizes to the labels for the other default sizes.
+ */
+add_filter('image_size_names_choose', function () {
+    return [
+        'thumbnail' => 'Thumbnail (150px)',
+        'medium' => 'Medium (300px)',
+        'medium_large' => 'Medium-Large (768px)',
+        'large' => 'Large (1024px)',
+        'full' => 'Full Size',
+    ];
+});
+
+
 /**
  * Prevent WordPress generating previews of PDF documents
  * Ref: https://www.wpbeginner.com/wp-tutorials/how-to-disable-pdf-thumbnail-previews-in-wordpress/


### PR DESCRIPTION
Implementing one of Mike's requests.  I don't think it correct to implement the other request.  See detailed reasoning in #5 