### PR TITLE
1047, 1049 protection for admin settings

### DIFF
--- a/cfg1.js
+++ b/cfg1.js
@@ -1,0 +1,3 @@
+// Add readonly property to siteurl and home fields
+document.getElementById("siteurl").setAttribute("readonly", "true");
+document.getElementById("home").setAttribute("readonly", "true");

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,8 @@ If these settings are not provided in wp-config.php then another mechanism must 
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Bug 1049: WMs are able to modify the WordPress Address (URL) resulting in a broken site
+* Bug 1047: It is possible for a WM to delete the SiteWorks administrative user
 = 1.1.0 =
 * Feature 1010 - Add facility for cautionary notice to the Add New Plugin page with link to SiteWorks help on plugins
 * Add medium_large to the list of image sizes available when adding an image in the block editor. (March 2024)


### PR DESCRIPTION
1047 Provide a degree of protection for a defined account login name if the constant U3A_SYSADMIN is defined in wp-config.php
  eg define( 'U3A_SYSADMIN', 'adminUserName' )

1049 Use JavaScript to add the readonly property to the fields in the General Settings page for WordPress Address (URL) and Site Address (URL) if the constant SITEWORKS_HOSTING is defined in wp-config.php
