### PR TITLE
remove quotes from max-age

### DIFF
--- a/u3a-siteworks-configuration.php
+++ b/u3a-siteworks-configuration.php
@@ -379,7 +379,7 @@ function add_security_headers()
 
     header("X-Content-Type-Options: nosniff");
 
-    header('Strict-Transport-Security: "max-age=31536000"');
+    header('Strict-Transport-Security: max-age=31536000');
 
     if (defined('CSP_REPORT_URL')) {
         $reporting_url = CSP_REPORT_URL;


### PR DESCRIPTION
Remove quotes around max-age, which confuse some HSTS tests.