### PR TITLE
1077 Make Administration Email Address read-only on SiteWorks hosting

### DIFF
--- a/cfg1.js
+++ b/cfg1.js
@@ -1,3 +1,6 @@
 // Add readonly property to siteurl and home fields
 document.getElementById("siteurl").setAttribute("readonly", "true");
 document.getElementById("home").setAttribute("readonly", "true");
+document.getElementById("home-description").setAttribute("style", "display:none;");
+document.getElementById("new_admin_email").setAttribute("readonly", "true");
+document.getElementById("new-admin-email-description").setAttribute("style", "display:none;");

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,8 @@ If these settings are not provided in wp-config.php then another mechanism must 
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+= 1.1.2 =
+* Bug 1077: Make Administration Email Address read-only (Settings->General) on SiteWorks hosting
 = 1.1.1 =
 * Bug 1049: WMs are able to modify the WordPress Address (URL) resulting in a broken site
 * Bug 1047: It is possible for a WM to delete the SiteWorks administrative user

--- a/u3a-siteworks-configuration.php
+++ b/u3a-siteworks-configuration.php
@@ -6,7 +6,7 @@
  * Author: u3a SiteWorks team
  * Author URI: https://siteworks.u3a.org.uk/
  * Plugin URI: https://siteworks.u3a.org.uk/
- * Version: 1.1.0
+ * Version: 1.1.2
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
  */
@@ -14,7 +14,7 @@
 if (!defined('ABSPATH')) {
     exit;
 }
-define('SW_CONFIGURATION_VERSION', '1.1.0');  // Set to current plugin version number
+define('SW_CONFIGURATION_VERSION', '1.1.2');  // Set to current plugin version number
 
 /*
  * Use the plugin update service on SiteWorks update server


### PR DESCRIPTION
A small extension to the JavaScript to make the field read-only and hide a couple of unnecessary messages.  Only applies if site is on SiteWorks project hosting.