### PR TITLE
OP1078 author can no longer delete pages

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-wp-configuration ===
 Requires at least: 5.9
-Tested up to: 6.5
+Tested up to: 6.6
 Stable tag: 5.9
 Requires PHP: 7.0
 License: GPLv2 or later
@@ -61,6 +61,8 @@ If these settings are not provided in wp-config.php then another mechanism must 
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+= 1.1.3 =
+* Bug 1078: Author should not be able to delete a Page assigned to them
 = 1.1.2 =
 * Bug 1077: Make Administration Email Address read-only (Settings->General) on SiteWorks hosting
 = 1.1.1 =

--- a/u3a-siteworks-configuration.php
+++ b/u3a-siteworks-configuration.php
@@ -6,7 +6,7 @@
  * Author: u3a SiteWorks team
  * Author URI: https://siteworks.u3a.org.uk/
  * Plugin URI: https://siteworks.u3a.org.uk/
- * Version: 1.1.2
+ * Version: 1.1.3
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
  */
@@ -14,7 +14,7 @@
 if (!defined('ABSPATH')) {
     exit;
 }
-define('SW_CONFIGURATION_VERSION', '1.1.2');  // Set to current plugin version number
+define('SW_CONFIGURATION_VERSION', '1.1.3');  // Set to current plugin version number
 
 /*
  * Use the plugin update service on SiteWorks update server
@@ -247,15 +247,13 @@ add_filter('login_site_html_link', 'u3a_back_to_blog_link');
 
 
 // change the default 'Author' role to allow editing pages
+// OP1078 do not provide capability for 'Author' to delete pages
 function u3a_change_author_role()
 {
     $role = get_role('author');
     $role->add_cap('edit_pages');
     $role->add_cap('edit_published_pages');
     $role->add_cap('publish_pages');
-    $role->add_cap('edit_published_pages');
-    $role->add_cap('delete_pages');
-    $role->add_cap('delete_published_pages');
 }
 add_action('admin_init', 'u3a_change_author_role');
 


### PR DESCRIPTION
Adjust the capabilities added to the author role.
Also bump the tested version of WordPress.