### PR TITLE
500 error

### DIFF
--- a/u3a-siteworks-configuration.php
+++ b/u3a-siteworks-configuration.php
@@ -280,7 +280,7 @@ add_filter('map_meta_cap', function ($caps, $cap, $user_id, $args) {
 
     // If current user has 'author' role, disallow delete for u3a group CPT
     $user = get_userdata($user_id);
-    if (in_array('author', $user->roles, true)) {
+    if (($user == false) || in_array('author', $user->roles, true)) {
         if (in_array(get_post_type($args[0]), ['u3a_group'], true))
             $caps[] = 'do_not_allow';
     }


### PR DESCRIPTION
I saw while investigating whether oversights could use the media library that our sites give a 500 error for most requests to the /v2/media.
The fix seems to be in our configuration, where we assume a user is present before refusing permission to delete items.
This is an example of the call:
https://siteworks-demo.local/wp-json/wp/v2/media?search=.jpg